### PR TITLE
Remove prefix from users router

### DIFF
--- a/app/api/v1/users/router.py
+++ b/app/api/v1/users/router.py
@@ -1,3 +1,3 @@
 from fastapi import APIRouter
 
-router = APIRouter(prefix="/users", tags=["users"])
+router = APIRouter(tags=["users"])


### PR DESCRIPTION
Removed the prefix '/users' from the router.

It was responsible for the signin failure as the backend url was malformed and frontend was hitting the right url